### PR TITLE
Make handle_error elixir 1.7+ compatible

### DIFF
--- a/lib/compiler_cache.ex
+++ b/lib/compiler_cache.ex
@@ -87,7 +87,7 @@ defmodule CompilerCache do
         try do
           eval_quoted(mod_def, expression, input)
         rescue
-          error -> mod_def.module.handle_error(error)
+          error -> mod_def.module.handle_error(error, System.stacktrace())
         end
 
       [{^key, compiled_module, ttl}] ->
@@ -126,7 +126,7 @@ defmodule CompilerCache do
       result
     rescue
       e ->
-        module.handle_error(e)
+        module.handle_error(e, System.stacktrace())
     end
   end
 
@@ -362,11 +362,11 @@ defmodule CompilerCache do
         GenServer.call(__MODULE__, :wait_for_completion, :infinity)
       end
 
-      def handle_error(error) do
-        reraise error, System.stacktrace
+      def handle_error(error, stacktrace) do
+        reraise error, stacktrace
       end
 
-      defoverridable [handle_error: 1]
+      defoverridable [handle_error: 2]
 
     end
   end

--- a/test/compiler_cache/context_test.exs
+++ b/test/compiler_cache/context_test.exs
@@ -15,7 +15,7 @@ defmodule Unit.CompilerCache.ContextTest do
       var * var
     end
 
-    def handle_error(e) do
+    def handle_error(e, _stacktrace) do
       IO.inspect e
     end
 


### PR DESCRIPTION
This is done by sending System.stacktrace() with the handle_error function.

It is a warning to use System.stacktrace() outside try/rescue blocks.